### PR TITLE
marisa: fix Illegal instruction error

### DIFF
--- a/mingw-w64-marisa/PKGBUILD
+++ b/mingw-w64-marisa/PKGBUILD
@@ -32,7 +32,7 @@ build() {
       local _conf=''      
     ;;
     x86_64*)
-      local _conf='--enable-native-code'
+      local _conf='--enable-sse2'
     ;;
   esac
   


### PR DESCRIPTION
--enable-native-code use -march=native which cause Illegal instruction error if the user's CPU older than builder's.    The oldest Intel x64 CPU core2 and the oldest AMD x64 CPU k8 both support SSE2.    So --enable-sse2 on x86_64 is safe.