### PR TITLE
fix glade-gtk2 crash

### DIFF
--- a/mingw-w64-glade-gtk2/PKGBUILD
+++ b/mingw-w64-glade-gtk2/PKGBUILD
@@ -4,7 +4,7 @@ _realname=glade
 pkgbase="mingw-w64-${_realname}-gtk2"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-gtk2"
 pkgver=3.8.6
-pkgrel=8
+pkgrel=9
 pkgdesc="User interface builder for GTK+ and GNOME (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -24,15 +24,19 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-gnome-common"
              "intltool")
 source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}3-${pkgver}.tar.xz
-        'disable-yelp.patch')
+        'disable-yelp.patch'
+        'widget-canonicalize-support-warning-property-name.patch')
 sha256sums=('aaeeebffaeb3068fb23757a2eede46adeb4c7cecc740feed7654e065491f5449'
-            '3e94072e1968a16247e0c35cea853316ef531e6c257a957d3d3e5b76137ed1b8')
+            '3e94072e1968a16247e0c35cea853316ef531e6c257a957d3d3e5b76137ed1b8'
+            '22668c905f7addf6bc257c1afce2edb33ce678675cdf47b001b2fe0a3ebce70f')
 
 prepare() {
   cd "${srcdir}/${_realname}3-${pkgver}"
 
   # itstool segfaults for some reason..
   patch -p1 -i "${srcdir}"/disable-yelp.patch
+  
+  patch -p1 -i "${srcdir}"/widget-canonicalize-support-warning-property-name.patch
 
   autoreconf -fi
 }
@@ -56,7 +60,7 @@ build() {
     --disable-python \
     --enable-compile-warnings=minimum
 
-  make VERBOSE=1
+  make -j
 }
 
 package() {

--- a/mingw-w64-glade-gtk2/widget-canonicalize-support-warning-property-name.patch
+++ b/mingw-w64-glade-gtk2/widget-canonicalize-support-warning-property-name.patch
@@ -1,0 +1,11 @@
+--- a/gladeui/glade-widget.c	2017-08-08 02:17:32 +0800
++++ b/gladeui/glade-widget.c	2025-08-27 15:50:42 +0800
+@@ -1192,7 +1192,7 @@
+ 
+ 	g_object_class_install_property
+ 		(object_class, 	PROP_SUPPORT_WARNING,
+-		 g_param_spec_string ("support warning", _("Support Warning"),
++		 g_param_spec_string ("support-warning", _("Support Warning"),
+ 				      _("A warning string about version mismatches"),
+ 				      NULL, G_PARAM_READABLE));
+ 


### PR DESCRIPTION
fix issue https://github.com/msys2/MINGW-packages/issues/25288
This is a known bug.
https://gitlab.gnome.org/Archive/glade/-/issues/403
And it is fixed by Christian Hergert.
https://gitlab.gnome.org/Archive/glade/-/merge_requests/83/diffs